### PR TITLE
Android | Clicking android hardware back button on splash screen opens blank screen

### DIFF
--- a/android/src/main/java/org/devio/rn/splashscreen/SplashScreen.java
+++ b/android/src/main/java/org/devio/rn/splashscreen/SplashScreen.java
@@ -34,7 +34,7 @@ public class SplashScreen {
         if (!activity.isFinishing()) {
           mSplashDialog = new Dialog(activity, themeResId);
           mSplashDialog.setContentView(R.layout.launch_screen);
-
+          mSplashDialog.setCancelable(false);
           LottieAnimationView lottie = (LottieAnimationView) mSplashDialog.findViewById(lottieId);
 
           lottie.addAnimatorListener(new Animator.AnimatorListener() {


### PR DESCRIPTION
**Issue**
[Android | Clicking android back button on splash screen opens blank screen]

[react-native-lottie-splash-screen](https://github.com/HwangTaehyun/react-native-lottie-splash-screen) is using [Android dialog](https://developer.android.com/guide/topics/ui/dialogs) to render the lottie animation as per the code of [react-native-lottie-splash-screen](https://github.com/HwangTaehyun/react-native-lottie-splash-screen/blob/master/android/src/main/java/org/devio/rn/splashscreen/SplashScreen.java?plain?1#L35-L38) it is opening the dialog and when user press the hardware back button on andorid device this closes the [Android dialog](https://developer.android.com/guide/topics/ui/dialogs), which show the blank screen of MainActivity.java

**Solution**
I am preventing [Android dialog](https://developer.android.com/guide/topics/ui/dialogs) to close on hardware back press. As per the [Android dialog documentation](https://developer.android.com/reference/android/app/Dialog#setCancelable(boolean)) there is a method available to achieve this. 