### PR TITLE
[fix] Set pkg type to `module`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "react-native-lottie-splash-screen",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A lottie splash screen for react-native, hide when application loaded ,it works on iOS and Android.",
+  "type": "module",
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {


### PR DESCRIPTION
since it's using `import` in index.js
this may fail tests running with node