### PR TITLE
Modify setAnimationFinished function to reflect argument value

### DIFF
--- a/ios/RNSplashScreen.m
+++ b/ios/RNSplashScreen.m
@@ -72,7 +72,7 @@ RCT_EXPORT_MODULE(SplashScreen)
 }
 
 + (void)setAnimationFinished:(Boolean)flag {
-    isAnimationFinished = true;
+    isAnimationFinished = flag;
     if (waiting) {
       dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)),
                      dispatch_get_main_queue(), ^{


### PR DESCRIPTION
I found that in the logic of `setAnimationFinished` function of the iOS part could not utilize the `flag` value, which is an argument, so corrected it.